### PR TITLE
BIP2-231 - DEX_EXTERNAL_URL 

### DIFF
--- a/helm-deployment/management-api-subchart/templates/management.yaml
+++ b/helm-deployment/management-api-subchart/templates/management.yaml
@@ -49,6 +49,10 @@ spec:
           value: "{{ .Values.platformDomain }}"
         - name: DEX_URL
           value: "{{ .Values.dexUrl }}"
+{{ if .Values.dexExternalURL }}
+        - name: DEX_EXTERNAL_URL
+          value: "{{ .Values.dexExternalURL }}"
+{{ end }}
         - name: PLATFORM_ADMIN
           value: "{{ .Values.platformAdmin }}"
         - name: ADMIN_SCOPE

--- a/helm-deployment/management-api-subchart/values.yaml
+++ b/helm-deployment/management-api-subchart/values.yaml
@@ -20,7 +20,7 @@ ingress:
      secretName: tls-management-secret
      hosts: <management_api_desired_dns>
 resources: {}
-platformDomain: <dns_for_manager>
+platformDomain: <dns_for_inference_endpoints>
 dexUrl: "https://dex.dex:443"
 dexTokenPath: "/dex/token"
 dexAuthPath: "/dex/auth"

--- a/management/management_api/authenticate/auth_controller.py
+++ b/management/management_api/authenticate/auth_controller.py
@@ -22,7 +22,7 @@ from jwt import jwk_from_dict
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 
-from management_api.config import AuthParameters, DEX_URL, PLATFORM_DOMAIN
+from management_api.config import AuthParameters, DEX_URL, DEX_EXTERNAL_URL
 from management_api.utils.errors_handling import MissingTokenException
 from management_api.utils.logger import get_logger
 
@@ -78,9 +78,8 @@ def _get_keys_from_dex():
 
 
 def get_dex_external_url():
-    host = "dex." + PLATFORM_DOMAIN
-    port = 443
-    url = f'https://{host}:{port}'
+    dex_external = DEX_EXTERNAL_URL
+    url = f'https://{dex_external}'
     return url
 
 

--- a/management/management_api/config.py
+++ b/management/management_api/config.py
@@ -32,6 +32,7 @@ PLATFORM_DOMAIN = os.getenv('PLATFORM_DOMAIN', 'default')
 PLATFORM_ADMIN = os.getenv('PLATFORM_ADMIN', 'platform_admin')
 
 DEX_URL = os.getenv('DEX_URL', 'https://dex:443')
+DEX_EXTERNAL_URL = os.getenv('DEX_EXTERNAL_URL', f'dex.{PLATFORM_DOMAIN}:443')
 
 
 # AUTH CONTROLLER DEFINITIONS:

--- a/tests/deployment/deployment_management_api.sh
+++ b/tests/deployment/deployment_management_api.sh
@@ -30,4 +30,8 @@ cd $RETURN_DIR
 fi
 MINIO_ENDPOINT="minio.default:9000"
 MINIO_URL="http://$MINIO_ENDPOINT"
-helm install --set image=$MGMT_IMAGE --set tag=$MGMT_TAG --set platformDomain=$DOMAIN_NAME --set ingress.hosts=${MGMT_DOMAIN_NAME} --set ingress.tls.hosts=${MGMT_DOMAIN_NAME} --set minio.endpoint=$MINIO_ENDPOINT --set minio.endpointUrl=$MINIO_URL --set minio.accessKey=$MINIO_ACCESS_KEY --set minio.secretKey=$MINIO_SECRET_KEY ../../helm-deployment/management-api-subchart/
+helm install --set image=$MGMT_IMAGE --set tag=$MGMT_TAG --set platformDomain=$DOMAIN_NAME \
+--set dexExternalURL=dex.${DOMAIN_NAME}:443 --set ingress.hosts=${MGMT_DOMAIN_NAME} \
+--set ingress.tls.hosts=${MGMT_DOMAIN_NAME} --set minio.endpoint=$MINIO_ENDPOINT \
+--set minio.endpointUrl=$MINIO_URL --set minio.accessKey=$MINIO_ACCESS_KEY \
+--set minio.secretKey=$MINIO_SECRET_KEY ../../helm-deployment/management-api-subchart/


### PR DESCRIPTION
* added DEX_EXTERNAL_URL env
* its default value is dex.${PLATFORM_DOMAIN}:443
* can be set with `--set dexExternalURL=<value>`  on helm deployment