### PR TITLE
Make base64 to work on MacOS

### DIFF
--- a/scripts/generate_certs.sh
+++ b/scripts/generate_certs.sh
@@ -10,5 +10,8 @@ echo 01 > /tmp/crlnumber
 touch /tmp/certindex
 openssl ca -config ca.conf -gencrl -keyfile ca-cert-tf.key -cert ca-cert-tf.crt -out root.crl.pem
 cat root.crl.pem >> ca-cert-tf.crt
-export CERT=`cat ca-cert-tf.crt|base64 -w0`
-
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    export CERT=`cat ca-cert-tf.crt|base64`
+else
+    export CERT=`cat ca-cert-tf.crt|base64 -w0`
+fi


### PR DESCRIPTION
MacOS base64 does not have -w option, no break is enabled by default. On MacOS you use -b option to break lines.

Signed-off-by: Sakari Poussa <sakari.poussa@intel.com>