### PR TITLE
fixed typo in main.sh in installer

### DIFF
--- a/installer/main.sh
+++ b/installer/main.sh
@@ -91,7 +91,7 @@ if [ "$MGT_API_AUTHORIZATION" == "false" ]; then
                 cd ..
         else
                 cd k8s
-                DEX_CA=`./get_ca_ing_cert.sh`
+                DEX_CA=`./get_ing_ca_cert.sh`
                 action_required "Please restart K8S API with OIDC config:\n oidcIssuerURL: $ISSUER: \noidcCA: $DEX_CA\noidcClientID: example-app\noidcGroupsClaim: groups\noidcUsernameClaim: email"
                 read -p "Press [ENTER] when ready"
                 cd -


### PR DESCRIPTION
* changed DEX_CA=`./get_ca_ing_crt.sh` to DEX_CA=`./get_ing_ca_crt.sh`